### PR TITLE
Update pm8xxx-keypad.kcm

### DIFF
--- a/rootdir/system/usr/keychars/pm8xxx-keypad.kcm
+++ b/rootdir/system/usr/keychars/pm8xxx-keypad.kcm
@@ -223,10 +223,10 @@ key X {
 
 key Y {
     label:                              'Y'
-    number:                             '9'
+    number:                             '6'
     base:                               'y'
     shift, capslock:                    'Y'
-    alt:                                ','
+    alt:                                '6'
     shift+alt, capslock+alt:            '\u00a1'
 }
 


### PR DESCRIPTION
Fix hw keyboard number input for number fields, e.g. for phone numbers in Contacts app. Applicable for both - QWERTY and QWERTZ layout.
